### PR TITLE
feat: include schema in the url, if not provided

### DIFF
--- a/src/tools/fetchUrl.ts
+++ b/src/tools/fetchUrl.ts
@@ -15,7 +15,7 @@ export const fetchUrlTool = {
     properties: {
       url: {
         type: "string",
-        description: "URL to fetch",
+        description: "URL to fetch. Make sure to include the schema (http:// or https:// if not defined, preferring https for most cases)",
       },
       timeout: {
         type: "number",


### PR DESCRIPTION
The current approach produces: 
![image](https://github.com/user-attachments/assets/07811428-8472-4c24-b378-d663e5357274)


when it should produce a url with a scheme